### PR TITLE
Implemented logic for incrementing/decrementing available spots when booking or cancelling a workout

### DIFF
--- a/BookingServiceApi/Controllers/BookingsController.cs
+++ b/BookingServiceApi/Controllers/BookingsController.cs
@@ -31,6 +31,17 @@ public class BookingsController(IBookingService bookingService) : ControllerBase
         }
     }
 
+    [HttpGet("member/{memberId}")]
+    public async Task<IActionResult> GetAllBookingsByMemberId(Guid memberId)
+    {
+        var response = await _bookingService.GetAllBookingsByMemberIdAsync(memberId);
+        if (response == null)
+            return NotFound();
+
+        return Ok(response);
+    }
+
+
     [HttpGet("{id}")]
     public async Task<IActionResult> GetBookingById(Guid id)
     {
@@ -42,10 +53,10 @@ public class BookingsController(IBookingService bookingService) : ControllerBase
         return Ok(response);
     }
 
-    [HttpDelete("{id}")]
-    public async Task<IActionResult> CancelBooking(Guid id)
+    [HttpDelete("{memberId}/{workoutId}")]
+    public async Task<IActionResult> CancelBooking(Guid memberId, Guid workoutId)
     {
-        var success = await _bookingService.CancelBookingAsync(id);
+        var success = await _bookingService.CancelBookingAsync(memberId, workoutId);
 
         if (!success)
             return NotFound();

--- a/BookingServiceApi/Controllers/BookingsController.cs
+++ b/BookingServiceApi/Controllers/BookingsController.cs
@@ -1,4 +1,5 @@
-﻿using Azure;
+﻿using System.Data;
+using Azure;
 using Business.Contracts.Requests;
 using Business.Interfaces;
 using Microsoft.AspNetCore.Authorization;
@@ -56,11 +57,19 @@ public class BookingsController(IBookingService bookingService) : ControllerBase
     [HttpDelete("{memberId}/{workoutId}")]
     public async Task<IActionResult> CancelBooking(Guid memberId, Guid workoutId)
     {
-        var success = await _bookingService.CancelBookingAsync(memberId, workoutId);
+        try
+        {
+            var success = await _bookingService.CancelBookingAsync(memberId, workoutId);
 
-        if (!success)
-            return NotFound();
+            if (!success)
+                return NotFound();
 
-        return NoContent();
+            return NoContent();
+        }
+        catch (InvalidExpressionException ex)
+        {
+            return Conflict( new { message  = ex.Message });
+        }
+
     }
 }

--- a/BookingServiceApi/Program.cs
+++ b/BookingServiceApi/Program.cs
@@ -30,11 +30,11 @@ builder.Services.AddDbContext<BookingContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
 builder.Services.AddScoped<IBookingService, BookingService>();
-
 builder.Services.AddScoped<IBookingRepository, BookingRepository>();
 
 builder.Services.AddControllers();
 builder.Services.AddOpenApi();
+builder.Services.AddHttpClient<IBookingService, BookingService>();
 
 builder.Services.AddCors(options =>
 {

--- a/BookingServiceApi/appsettings.json
+++ b/BookingServiceApi/appsettings.json
@@ -1,5 +1,6 @@
 {
-  "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=BookingServiceDb;Trusted_Connection=True;MultipleActiveResultSets=true"
-  }
+    "ConnectionStrings": {
+        "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=BookingServiceDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+    },
+    "ScheduleServiceBaseUrl": "https://localhost:7214"
 }

--- a/BookingServiceApi/appsettings.json
+++ b/BookingServiceApi/appsettings.json
@@ -1,6 +1,6 @@
 {
     "ConnectionStrings": {
-        "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=BookingServiceDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+        "DefaultConnection": "Data Source=(LocalDB)\\MSSQLLocalDB;AttachDbFilename=C:\\Databases\\test_booking_db.mdf;Integrated Security=True;Connect Timeout=30;Encrypt=True"
     },
     "ScheduleServiceBaseUrl": "https://localhost:7214"
 }

--- a/Business/Interfaces/IBookingService.cs
+++ b/Business/Interfaces/IBookingService.cs
@@ -9,4 +9,8 @@ public interface IBookingService
     Task<IEnumerable<BookingResponse>?> GetAllBookingsByMemberIdAsync(Guid memberId);
     Task<BookingResponse?> GetBookingByIdAsync(Guid id);
     Task<bool> CancelBookingAsync(Guid memberId, Guid workoutId);
+
+    Task<bool> HasAvailableSpotsAsync(string baseUrl, Guid workoutId);
+    Task IncrementSpotsAsync(string baseUrl, Guid workoutId);
+    Task DecrementSpotsAsync(string baseUrl, Guid workoutId);
 }

--- a/Business/Interfaces/IBookingService.cs
+++ b/Business/Interfaces/IBookingService.cs
@@ -6,6 +6,7 @@ namespace Business.Interfaces;
 public interface IBookingService
 {
     Task<BookingResponse> CreateBookingAsync(CreateBookingRequest request);
+    Task<IEnumerable<BookingResponse>?> GetAllBookingsByMemberIdAsync(Guid memberId);
     Task<BookingResponse?> GetBookingByIdAsync(Guid id);
-    Task<bool> CancelBookingAsync(Guid id);
+    Task<bool> CancelBookingAsync(Guid memberId, Guid workoutId);
 }

--- a/Business/Mappings/BookingMapper.cs
+++ b/Business/Mappings/BookingMapper.cs
@@ -14,7 +14,6 @@ public static class BookingMapper
             WorkoutId = entity.WorkoutId,
             CreatedAt = entity.CreatedAt,
             IsCancelled = entity.IsCancelled
-
         };
     }
 }

--- a/Business/Services/BookingService.cs
+++ b/Business/Services/BookingService.cs
@@ -1,41 +1,89 @@
-﻿using Business.Contracts.Requests;
+﻿using System.Buffers.Text;
+using Azure.Core;
+using Business.Contracts.Requests;
 using Business.Contracts.Responses;
 using Business.Factories;
 using Business.Interfaces;
 using Business.Mappings;
 using Data.Context;
 using Data.Interfaces;
+using Microsoft.Extensions.Configuration;
 
 namespace Business.Services;
 
-public class BookingService(IBookingRepository repository, BookingContext context) : IBookingService
+public class BookingService(IBookingRepository repository, BookingContext context, HttpClient httpClient, IConfiguration configuration) : IBookingService
 {
     private readonly IBookingRepository _repository = repository;
     private readonly BookingContext _context = context;
+    private readonly HttpClient _httpClient = httpClient;
+    private readonly IConfiguration _configuration = configuration;
 
     public async Task<BookingResponse> CreateBookingAsync(CreateBookingRequest request)
     {
+        var baseUrl = _configuration["ScheduleServiceBaseUrl"];
+
         var booking = await _repository.GetAsync(x => x.MemberId == request.MemberId && x.WorkoutId == request.WorkoutId);
 
+        //om bokning redan finns
         if (booking != null)
         {
             if (booking.IsCancelled)
             {
+                // kontrollera om plats finns
+                if (!await HasAvailableSpotsAsync(baseUrl, request.WorkoutId))
+                    throw new InvalidOperationException("No available spots.");
+
                 booking.IsCancelled = false;
                 await _repository.UpdateAsync(booking);
+
+                // increment spots
+                await IncrementSpotsAsync(baseUrl, request.WorkoutId);
+
                 return BookingMapper.ToResponse(booking);
             }
 
             throw new InvalidOperationException("Member is already booked for this workout.");
         }
 
-        booking = BookingFactory.Create(request);
+        //ny bokning
 
+        // kontrollera om plats finns
+        if (!await HasAvailableSpotsAsync(baseUrl, request.WorkoutId))
+            throw new InvalidOperationException("No available spots.");
+
+        booking = BookingFactory.Create(request);
         await _repository.AddAsync(booking);
         await _context.SaveChangesAsync();
 
+        // increment spots
+        await IncrementSpotsAsync(baseUrl, request.WorkoutId);
+
         return BookingMapper.ToResponse(booking);
     }
+
+    public async Task<bool> HasAvailableSpotsAsync(string baseUrl, Guid workoutId)
+    {
+        var response = await _httpClient.GetAsync($"{baseUrl}/api/workouts/has-available-spots/{workoutId}");
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException("Could not check available spots.");
+
+        return bool.Parse(await response.Content.ReadAsStringAsync());
+    }
+
+    public async Task IncrementSpotsAsync(string baseUrl, Guid workoutId)
+    {
+        var response = await _httpClient.PostAsync($"{baseUrl}/api/workouts/increment/{workoutId}", null);
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException("Could not increment spots.");
+    }
+
+    public async Task DecrementSpotsAsync(string baseUrl, Guid workoutId)
+    {
+        var response = await _httpClient.PostAsync($"{baseUrl}/api/workouts/decrement/{workoutId}", null);
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException("Could not decrement spots.");
+    }
+
 
     public async Task<IEnumerable<BookingResponse>?> GetAllBookingsByMemberIdAsync(Guid memberId)
     {

--- a/Business/Services/BookingService.cs
+++ b/Business/Services/BookingService.cs
@@ -15,11 +15,21 @@ public class BookingService(IBookingRepository repository, BookingContext contex
 
     public async Task<BookingResponse> CreateBookingAsync(CreateBookingRequest request)
     {
-        var alreadyBooked = await _repository.ExistsAsync(request.WorkoutId, request.MemberId);
-        if (alreadyBooked)
-            throw new InvalidOperationException("Member is already booked for this workout.");
+        var booking = await _repository.GetAsync(x => x.MemberId == request.MemberId && x.WorkoutId == request.WorkoutId);
 
-        var booking = BookingFactory.Create(request);
+        if (booking != null)
+        {
+            if (booking.IsCancelled)
+            {
+                booking.IsCancelled = false;
+                await _repository.UpdateAsync(booking);
+                return BookingMapper.ToResponse(booking);
+            }
+
+            throw new InvalidOperationException("Member is already booked for this workout.");
+        }
+
+        booking = BookingFactory.Create(request);
 
         await _repository.AddAsync(booking);
         await _context.SaveChangesAsync();
@@ -27,6 +37,15 @@ public class BookingService(IBookingRepository repository, BookingContext contex
         return BookingMapper.ToResponse(booking);
     }
 
+    public async Task<IEnumerable<BookingResponse>?> GetAllBookingsByMemberIdAsync(Guid memberId)
+    {
+        var bookings = await _repository.GetAllAsync(x => x.MemberId == memberId);
+
+        if (bookings == null)
+            return null;
+
+        return bookings.Select(BookingMapper.ToResponse).ToList();
+    }
     public async Task<BookingResponse?> GetBookingByIdAsync(Guid id)
     {
         var booking = await _repository.GetByIdAsync(id);
@@ -37,11 +56,11 @@ public class BookingService(IBookingRepository repository, BookingContext contex
         return BookingMapper.ToResponse(booking);  
     }
 
-    public async Task<bool> CancelBookingAsync(Guid id)
+    public async Task<bool> CancelBookingAsync(Guid memberId, Guid workoutId)
     {
         //Add business logic like time restrictions for cancelling here if needed
 
-        var booking = await _repository.GetByIdAsync(id);
+        var booking = await _repository.GetAsync(x => x.MemberId == memberId &&  x.WorkoutId == workoutId);
 
         if (booking == null || booking.IsCancelled)
             return false;

--- a/Business/Services/BookingService.cs
+++ b/Business/Services/BookingService.cs
@@ -108,6 +108,8 @@ public class BookingService(IBookingRepository repository, BookingContext contex
     {
         //Add business logic like time restrictions for cancelling here if needed
 
+        var baseUrl = _configuration["ScheduleServiceBaseUrl"];
+
         var booking = await _repository.GetAsync(x => x.MemberId == memberId &&  x.WorkoutId == workoutId);
 
         if (booking == null || booking.IsCancelled)
@@ -115,6 +117,8 @@ public class BookingService(IBookingRepository repository, BookingContext contex
         
         _repository.MarkAsCancelled(booking);
         await _context.SaveChangesAsync();
+
+        await DecrementSpotsAsync(baseUrl, workoutId);
 
         return true;
     }

--- a/Data/Interfaces/IBookingRepository.cs
+++ b/Data/Interfaces/IBookingRepository.cs
@@ -1,11 +1,15 @@
-﻿using Data.Entities;
+﻿using System.Linq.Expressions;
+using Data.Entities;
 
 namespace Data.Interfaces;
 
 public interface IBookingRepository
 {
     Task AddAsync (BookingEntity booking);
+    Task<IEnumerable<BookingEntity>> GetAllAsync(Expression<Func<BookingEntity, bool>> predicate = null!, Func<IQueryable<BookingEntity>, IQueryable<BookingEntity>>? includeExpression = null);
     Task<BookingEntity?> GetByIdAsync (Guid id);
+    Task<BookingEntity?> GetAsync(Expression<Func<BookingEntity, bool>> expression);
+    Task<BookingEntity?> UpdateAsync(BookingEntity entity);
     Task<bool> ExistsAsync(Guid workoutId, Guid memberId);
     void MarkAsCancelled(BookingEntity booking);
 }

--- a/Data/Repositories/BookingRepository.cs
+++ b/Data/Repositories/BookingRepository.cs
@@ -1,4 +1,5 @@
-﻿using Data.Context;
+﻿using System.Linq.Expressions;
+using Data.Context;
 using Data.Entities;
 using Data.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -9,15 +10,45 @@ public class BookingRepository(BookingContext context) : IBookingRepository
 {
     private readonly BookingContext _context = context;
 
+    #region Create
     public async Task AddAsync(BookingEntity booking)
     {
         await _context.Bookings.AddAsync(booking);
+    }
+    #endregion
+
+    #region Read
+    public async Task<IEnumerable<BookingEntity>> GetAllAsync(Expression<Func<BookingEntity, bool>> predicate = null!, Func<IQueryable<BookingEntity>, IQueryable<BookingEntity>>? includeExpression = null)
+    {
+        IQueryable<BookingEntity> query = _context.Bookings;
+        if (includeExpression != null)
+            query = includeExpression(query);
+
+        if(predicate != null)
+            query = query.Where(predicate);
+
+        return await query.ToListAsync();
     }
 
     public async Task<BookingEntity?> GetByIdAsync(Guid id)
     {
         return await _context.Bookings.FindAsync(id);
     }
+
+    public async Task<BookingEntity?> GetAsync(Expression<Func<BookingEntity, bool>> expression)
+    {
+        return await _context.Bookings.FirstOrDefaultAsync(expression);
+    }
+    #endregion
+
+    #region Update
+    public async Task<BookingEntity?> UpdateAsync(BookingEntity entity)
+    {
+        _context.Bookings.Update(entity);
+        var updated = await _context.SaveChangesAsync();
+        return updated > 0 ? entity : null;
+    }
+    #endregion
 
     public async Task<bool> ExistsAsync(Guid workoutId, Guid memberId)
     {


### PR DESCRIPTION
Controller:
   - Updated DELETE/api/booking/CancelBooking to use memberId + workoutId instead of bookingId (supports cancelling without knowing bookingId)
   - Added GET /api/booking/GetAllBookingsByMemberId to list all bookings for a logged-in member

Service:
- Added HttpClient and IConfiguration
- Added HasAvailableSpotsAsync, IncrementSpotsAsync, DecrementSpotsAsync to communicate with ScheduleService
- Updated CreateBooking to check for previously cancelled bookings before creating a new one
- Added GetAllBookingsByMemberIdAsync

Repository:
- Added GetAllAsync with predicate and includeExpression
- Added GetAsync with expression
- Added UpdateAsync

Testing:
Verified all endpoints with Postman
- Booking decrements available spots
- Cancelling increments spots
- Member can list/see their own bookings